### PR TITLE
Fixes select all + arrow behavior

### DIFF
--- a/morphic.js
+++ b/morphic.js
@@ -8047,8 +8047,13 @@ StringMorph.prototype.deleteSelection = function () {
 };
 
 StringMorph.prototype.selectAll = function () {
+    var cursor;
     if (this.isEditable) {
         this.startMark = 0;
+        cursor = this.root().cursor;
+        if (cursor) {
+            cursor.gotoSlot(this.text.length);
+        }
         this.endMark = this.text.length;
         this.drawNew();
         this.changed();


### PR DESCRIPTION
Basically, it puts the cursor at the end of the selected text. This is NOT what OSes do, or at least not what mine does, but what OSes do, to my understanding, is inconsistent:

* **Select all + →** gets you to the end of the text, same with shift held
* **Select all + ↑** gets you one line above the last one, same with shift held
* **Select all + ↓** gets you to the end of the text, same with shift held
* **Select all + ←** gets you to the BEGINNING of the text (why?? all the other cases started from the cursor being at the END of the text), but
* **Select all + Shift + ←** gets you to the END of the text and deselects the last character (or the last word, if you hold control)

So, essentially, this code does the same except for the **←** case, which IMO is inconsistent with the rest and doesn't make much sense. Correct me if you think I should implement it like that, in which case we need to add a stupid special case to `goLeft` that checks if all text is selected before moving the cursor...