### PR TITLE
Place the clipboard handler just out of view vertically as well.

### DIFF
--- a/morphic.js
+++ b/morphic.js
@@ -5244,6 +5244,7 @@ CursorMorph.prototype.initializeClipboardHandler = function () {
 
     this.clipboardHandler = document.createElement('textarea');
     this.clipboardHandler.style.position = 'absolute';
+    this.clipboardHandler.style.top = window.outerHeight;
     this.clipboardHandler.style.right = '101%'; // placed just out of view
 
     document.body.appendChild(this.clipboardHandler);


### PR DESCRIPTION
Place the clipboard handler just out of view vertically as well. Otherwise, if morphic.js doesn't take up the whole page vertically, the page will scroll undesirably when the clipboard handler is focused.