### PR TITLE
Ensure menu is active before clearing. Fixes #55

### DIFF
--- a/morphic.js
+++ b/morphic.js
@@ -8400,7 +8400,8 @@ MenuMorph.prototype.destroy = function () {
     if (this.hasFocus) {
         this.world.keyboardFocus = null;
     }
-    if (!this.isListContents) {
+    const isActiveMenu = this.world.activeMenu === this;
+    if (!this.isListContents && isActiveMenu) {
         this.world.activeMenu = null;
     }
     MenuMorph.uber.destroy.call(this);


### PR DESCRIPTION
Hi Jens!

It seems to me that a menu shouldn't ever be clearing the `activeMenu` if something else is in fact the active menu so I just added a check to guarantee it. I am not sure if this is how you want to address #55 but I figured I would push it anyway just in case. 

Hope all is well!