### PR TITLE
Add threshold to right-click on mobile

### DIFF
--- a/morphic.js
+++ b/morphic.js
@@ -11270,6 +11270,7 @@ HandMorph.prototype.init = function (aWorld) {
     this.temporaries = [];
     this.touchHoldTimeout = null;
     this.contextMenuEnabled = false;
+    this.touchStartPosition = [];
 
     // properties for caching dragged objects:
     this.cachedFullImage = null;
@@ -11516,6 +11517,11 @@ HandMorph.prototype.processTouchStart = function (event) {
     MorphicPreferences.isTouchDevice = true;
     clearInterval(this.touchHoldTimeout);
     if (event.touches.length === 1) {
+        this.touchStartPosition = [
+            event.touches[0].pageX,
+            event.touches[0].pageY
+        ];
+
         this.touchHoldTimeout = setInterval( // simulate mouseRightClick
             () => {
                 this.processMouseDown({button: 2});
@@ -11533,10 +11539,28 @@ HandMorph.prototype.processTouchStart = function (event) {
 
 HandMorph.prototype.processTouchMove = function (event) {
     MorphicPreferences.isTouchDevice = true;
-    if (event.touches.length === 1) {
-        var touch = event.touches[0];
-        this.processMouseMove(touch);
-        clearInterval(this.touchHoldTimeout);
+
+    let pos = [
+        event.touches[0].pageX,
+        event.touches[0].pageY
+    ];
+
+    let dis = new Point(
+        this.touchStartPosition[0],
+        this.touchStartPosition[1]
+    ).distanceTo(
+        new Point(
+            pos[0],
+            pos[1]
+        )
+    );
+
+    if (dis > MorphicPreferences.grabThreshold) {
+        if (event.touches.length === 1) {
+            var touch = event.touches[0];
+            this.processMouseMove(touch);
+            clearInterval(this.touchHoldTimeout);
+        }
     }
 };
 

--- a/morphic.js
+++ b/morphic.js
@@ -11270,7 +11270,7 @@ HandMorph.prototype.init = function (aWorld) {
     this.temporaries = [];
     this.touchHoldTimeout = null;
     this.contextMenuEnabled = false;
-    this.touchStartPosition = [];
+    this.touchStartPosition = new Point();
 
     // properties for caching dragged objects:
     this.cachedFullImage = null;
@@ -11517,10 +11517,10 @@ HandMorph.prototype.processTouchStart = function (event) {
     MorphicPreferences.isTouchDevice = true;
     clearInterval(this.touchHoldTimeout);
     if (event.touches.length === 1) {
-        this.touchStartPosition = [
+        this.touchStartPosition = new Point(
             event.touches[0].pageX,
             event.touches[0].pageY
-        ];
+        );
 
         this.touchHoldTimeout = setInterval( // simulate mouseRightClick
             () => {
@@ -11540,20 +11540,12 @@ HandMorph.prototype.processTouchStart = function (event) {
 HandMorph.prototype.processTouchMove = function (event) {
     MorphicPreferences.isTouchDevice = true;
 
-    let pos = [
+    let pos = new Point(
         event.touches[0].pageX,
         event.touches[0].pageY
-    ];
-
-    let dis = new Point(
-        this.touchStartPosition[0],
-        this.touchStartPosition[1]
-    ).distanceTo(
-        new Point(
-            pos[0],
-            pos[1]
-        )
     );
+
+    let dis = this.touchStartPosition.distanceTo(pos);
 
     if (dis > MorphicPreferences.grabThreshold) {
         if (event.touches.length === 1) {


### PR DESCRIPTION
I noticed that on my phone, I was unable to right-click. I thought it was because my phone was using mouse events, but when I modified the code to allow touch and hold with a mouse, it still didn't work. I eventually found out that it was because when right-clicking, there is no threshold, so my finger was moving ever so slightly, therefore preventing me from right-clicking.

I fixed this issue by adding a threshold to the `processTouchMove` function. It just uses the `MorphicPreferences.grabThreshold` value for the threshold.

I know that this fix will make the mobile experience much better.