### PR TITLE
Add cursor style for morphs

### DIFF
--- a/morphic.js
+++ b/morphic.js
@@ -3236,6 +3236,7 @@ Morph.prototype.init = function () {
     this.customContextMenu = null;
     this.lastTime = Date.now();
     this.onNextStep = null; // optional function to be run once
+    this.cursorStyle = null;
 };
 
 // Morph string representation: e.g. 'a Morph 2 [20@45 | 130@250]'
@@ -11264,6 +11265,7 @@ HandMorph.prototype.init = function (aWorld) {
     // properties for caching dragged objects:
     this.cachedFullImage = null;
     this.cachedFullBounds = null;
+    this.cursorStyle = 'auto';
 };
 
 // HandMorph dragging optimizations:
@@ -11605,6 +11607,8 @@ HandMorph.prototype.processMouseMove = function (event) {
         mouseOverBoundsNew,
         morph,
         topMorph;
+    
+    this.cursorStyle = null;
 
     pos = new Point(
         event.pageX - posInDocument.x,
@@ -11654,6 +11658,7 @@ HandMorph.prototype.processMouseMove = function (event) {
             }
             this.setPosition(pos);
         }
+        this.cursorStyle = morph.cursorStyle;
     }
 
     this.mouseOverBounds.forEach(old => {
@@ -11709,6 +11714,18 @@ HandMorph.prototype.processMouseMove = function (event) {
     });
     this.mouseOverList = mouseOverNew;
     this.mouseOverBounds = mouseOverBoundsNew;
+
+    if (this.cursorStyle == null) {
+        this.cursorStyle = 'auto';
+    
+        for (const morph of this.mouseOverList) {
+            if (morph.cursorStyle != null) {
+                this.cursorStyle = morph.cursorStyle;
+                break;
+            }
+        }
+    }
+    this.world.worldCanvas.style.cursor = this.cursorStyle;
 };
 
 HandMorph.prototype.processMouseScroll = function (event) {

--- a/morphic.js
+++ b/morphic.js
@@ -11658,7 +11658,6 @@ HandMorph.prototype.processMouseMove = function (event) {
             }
             this.setPosition(pos);
         }
-        this.cursorStyle = morph.cursorStyle;
     }
 
     this.mouseOverBounds.forEach(old => {
@@ -11715,8 +11714,10 @@ HandMorph.prototype.processMouseMove = function (event) {
     this.mouseOverList = mouseOverNew;
     this.mouseOverBounds = mouseOverBoundsNew;
 
+    if (this.mouseButton === 'left' && this.morphToGrab) {
+        this.cursorStyle = this.morphToGrab.cursorStyle;
+    }
     if (this.cursorStyle == null) {
-        this.cursorStyle = 'auto';
     
         for (const morph of this.mouseOverList) {
             if (morph.cursorStyle != null) {


### PR DESCRIPTION
This adds a new `cursorStyle` attribute to `Morph`s, which is what the cursor turns into when hovering over the `Morph`. It's initially `null`, which you can change to any css cursor. The code that changes the cursor (aka, sets the canvas style to show the cursor) looks for the first `Morph` under the mouse that does not have a `null` `cursorStyle`, and then uses that. I also made sure to keep the cursor when dragging a `Morph` (unless it's `null`, we can discuss whether that's the best behavior).

I just decided to do this because I felt that it would make snap feel more interactive.