### PR TITLE
Add shift scrolling

### DIFF
--- a/morphic.js
+++ b/morphic.js
@@ -11712,21 +11712,24 @@ HandMorph.prototype.processMouseMove = function (event) {
 };
 
 HandMorph.prototype.processMouseScroll = function (event) {
-    var morph = this.morphAtPointer();
+    var morph = this.morphAtPointer(),
+        shiftPressed = this.world.currentKey === 16;
     while (morph && !morph.mouseScroll) {
         morph = morph.parent;
     }
-    if (morph) {
-        morph.mouseScroll(
-            (event.detail / -3) || (
+    let y = (event.detail / -3) || (
                 Object.prototype.hasOwnProperty.call(
                     event,
                     'wheelDeltaY'
                 ) ?
                         event.wheelDeltaY / 120 :
                         event.wheelDelta / 120
-            ),
-            event.wheelDeltaX / 120 || 0
+            )
+    let x = event.wheelDeltaX / 120 || 0
+    if (morph) {
+        morph.mouseScroll(
+            shiftPressed ? x : y,
+            shiftPressed ? y : x,
         );
     }
 };


### PR DESCRIPTION
When you hold shift while scrolling, it scrolls on the x axis instead of the y axis. This has been needed for so long, because it is really annoying to have to drag the scripting area whenever I want to scroll on the x axis (it also helps with muscle memory that people have built up using the browser).

All this does is, check if the shift key is pressed, and if it is, just switch the y and x variables.